### PR TITLE
Fix for `ShopConfigurator` update

### DIFF
--- a/code/composer.json
+++ b/code/composer.json
@@ -12,6 +12,7 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
+        "composer/semver": "*",
         "shopware/platform": "^6.5||^6.6",
         "swag/language-pack": "^3.1||^4.1",
         "symfony/browser-kit": "^6.2||^7.0",

--- a/code/src/Setup/AfterInstallConfigurator.php
+++ b/code/src/Setup/AfterInstallConfigurator.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace ITB\ShopwareRemoteApiTestRunner\Setup;
 
+use Composer\InstalledVersions;
+use Composer\Semver\Comparator;
 use Doctrine\DBAL\Connection;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Maintenance\System\Service\ShopConfigurator;
@@ -14,23 +17,36 @@ final class AfterInstallConfigurator
     use AdminApiTestBehaviour;
     use IntegrationTestBehaviour;
 
-    public function changeSystemCurrency(string $currency): void
+    private readonly ShopConfigurator $shopConfigurator;
+
+    public function __construct()
     {
+        $shopConfiguratorConstructorArguments = [];
+
         /** @var Connection $connection */
         $connection = $this->getBrowser()
             ->getContainer()
             ->get(Connection::class);
-        $shopConfigurator = new ShopConfigurator($connection);
-        $shopConfigurator->setDefaultCurrency($currency);
+        $shopConfiguratorConstructorArguments[] = $connection;
+
+        if (Comparator::greaterThanOrEqualTo(InstalledVersions::getVersion('shopware/platform'), '6.6.10.0')) {
+            /** @var EventDispatcherInterface $eventDispatcher */
+            $eventDispatcher = $this->getBrowser()
+                ->getContainer()
+                ->get(EventDispatcherInterface::class);
+            $shopConfiguratorConstructorArguments[] = $eventDispatcher;
+        }
+
+        $this->shopConfigurator = new ShopConfigurator(...$shopConfiguratorConstructorArguments);
+    }
+
+    public function changeSystemCurrency(string $currency): void
+    {
+        $this->shopConfigurator->setDefaultCurrency($currency);
     }
 
     public function changeSystemLanguage(string $locale): void
     {
-        /** @var Connection $connection */
-        $connection = $this->getBrowser()
-            ->getContainer()
-            ->get(Connection::class);
-        $shopConfigurator = new ShopConfigurator($connection);
-        $shopConfigurator->setDefaultLanguage($locale);
+        $this->shopConfigurator->setDefaultLanguage($locale);
     }
 }

--- a/code/src/Setup/DatabaseBackupExecutor.php
+++ b/code/src/Setup/DatabaseBackupExecutor.php
@@ -14,23 +14,26 @@ final class DatabaseBackupExecutor
     use AdminApiTestBehaviour;
     use IntegrationTestBehaviour;
 
+    private readonly Connection $connection;
+
     public function __construct(
         private readonly string $backupDirectory
     ) {
-    }
-
-    public function createDatabaseBackup(): void
-    {
         /** @var Connection $connection */
         $connection = $this->getBrowser()
             ->getContainer()
             ->get(Connection::class);
 
+        $this->connection = $connection;
+    }
+
+    public function createDatabaseBackup(): void
+    {
         /** @var string $dbName */
-        $dbName = $connection->getDatabase();
+        $dbName = $this->connection->getDatabase();
 
         /** @var array<string, mixed> $params */
-        $params = $connection->getParams();
+        $params = $this->connection->getParams();
         $passwordString = '';
         if ($params['password'] ?? '') {
             $passwordString = '-p' . escapeshellarg($params['password']);

--- a/code/src/Setup/DatabaseRestoreExecutor.php
+++ b/code/src/Setup/DatabaseRestoreExecutor.php
@@ -14,23 +14,26 @@ final class DatabaseRestoreExecutor
     use AdminApiTestBehaviour;
     use IntegrationTestBehaviour;
 
+    private readonly Connection $connection;
+
     public function __construct(
         private readonly string $backupDirectory
     ) {
-    }
-
-    public function restoreDatabaseFromBackup(): void
-    {
         /** @var Connection $connection */
         $connection = $this->getBrowser()
             ->getContainer()
             ->get(Connection::class);
 
+        $this->connection = $connection;
+    }
+
+    public function restoreDatabaseFromBackup(): void
+    {
         /** @var string $dbName */
-        $dbName = $connection->getDatabase();
+        $dbName = $this->connection->getDatabase();
 
         /** @var array<string, mixed> $params */
-        $params = $connection->getParams();
+        $params = $this->connection->getParams();
         $passwordString = '';
         if ($params['password'] ?? '') {
             $passwordString = '-p' . escapeshellarg($params['password']);


### PR DESCRIPTION
Shopware 6.6.10.0 extended the `ShopConfigurator` with an event system that allows to react to changes in the default language. That's why the constructor requires and event dispatcher implementation. This fix fetches and passes one if the Shopware version is >= 6.6.10.0.